### PR TITLE
fix: disable automount for dde-file-manager

### DIFF
--- a/calamares-modules/disable-automount/module.desc
+++ b/calamares-modules/disable-automount/module.desc
@@ -1,0 +1,6 @@
+---
+type:       "job"
+name:       "disable-automount"
+interface:  "process"
+command:    "/usr/sbin/disable-automount"
+timeout:    600

--- a/calamares/settings.conf
+++ b/calamares/settings.conf
@@ -59,6 +59,7 @@ sequence:
 # view module jobs should be enqueued. Job modules are
 # also allowed.
 - exec:
+  - disable-automount
   - partition
   - mount
   - unpackfs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+calamares-settings-deepin (1.0.2) unstable; urgency=medium
+
+  * disable automount for dde-file-manager
+
+ -- bluesky <chenchongbiao@deepin.org>  Tue, 15 Jul 2025 17:45:43 +0800
+
 calamares-settings-deepin (1.0.1) unstable; urgency=medium
 
   * Fix error grub install

--- a/scripts/disable-automount
+++ b/scripts/disable-automount
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Running disable automount for dde-file-manager..."
+
+if [ ! -d /sys/firmware/efi/efivars ]; then
+    echo " * install grub... (bios), skipping automount configuration"
+    USER="$(ls /home | head -n 1)"
+    DDE_FILE_CONFIG="/home/$USER/.config/deepin/dde-file-manager.json"
+    echo "{\"GenericAttribute\": {\"AutoMount\": false}}" > "$DDE_FILE_CONFIG"
+fi


### PR DESCRIPTION
在传统引导下禁用 dde-file-manager 的自动挂载，分区完后由于自动挂载导致分区无法被格式化。